### PR TITLE
try opening the article in less before piping it into PAGER

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -5,6 +5,9 @@ var cheerio = require('cheerio');
 var htmlToText = require('html-to-text');
 var Stream = require('string-stream');
 var pager = require('default-pager');
+var tmp = require('tmp');
+var spawn = require('child_process').spawn;
+var fs = require('fs');
 // var urlParser = require('url');
 
 // var url = 'https://medium.com/@googleforwork/one-googler-s-take-on-managing-your-time-b441537ae037';
@@ -15,9 +18,17 @@ function getTextFromHtml(html) {
 
 function printArticle(content) {
 	var readStream = new Stream(content);
-	readStream.pipe(pager(function () {
-		console.log('(END)');
-	}));
+	// make temp file (gets cleaned later automatically)
+	var tempFile = tmp.fileSync().name;
+	fs.writeFileSync(tempFile, content, 'utf8');
+
+	try {
+		spawn('less', [tempFile], { stdio: 'inherit' });
+	} catch(e) {
+		readStream.pipe(pager(function () {
+			console.log('(END)');
+		}));
+	}
 }
 
 function parseContent(html) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "q": "^1.4.1",
     "request": "^2.67.0",
     "request-promise": "^2.0.0",
-    "string-stream": "0.0.7"
+    "string-stream": "0.0.7",
+    "tmp": "0.0.28"
   },
   "homepage": "https://github.com/djadmin/medium-cli#readme",
   "bugs": {


### PR DESCRIPTION
It comes at the cost of a single small dependency, but this change results in the chosen article to be saved into a temporary file and opened in `less`. If it errors out (which should mean that `less` doesn't exist), it falls back to piping the stream into $PAGER. The temporary file is cleaned automatically when the process exits.

The main advantage of `less` is that you can scroll a line, half a page or a page up and go back to the beginning etc. Just better navigation in general.