### PR TITLE
Fix medium cli

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -22,7 +22,7 @@ function printArticle(content) {
 
 function parseContent(html) {
 	var $ = cheerio.load(html);
-	var articleMarkup = $('main.postArticle-content').html();
+	var articleMarkup = $('.postArticle-content').html();
 	var content = getTextFromHtml(articleMarkup);
 	return content;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediumcli",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Medium for Hackers - A CLI to Medium Stories",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
A few days ago, mediumcli stopped parsing medium articles due to a little change in medium.com's HTML layout.
