### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Opens it in your browser
 
 Opens it in the given application, like it opens the url using firefox in above example.
 
-####Also, you can search by **Author, Tags or Keyword**
+#### Also, you can search by **Author, Tags or Keyword**
 
 `$ medium author _ericelliott`  
 
@@ -85,7 +85,7 @@ Opens it in the given application, like it opens the url using firefox in above 
 
 `$ medium search security`
 
-####Another Example
+#### Another Example
 `$ medium author dheerajhere --open` will open the selected story in browser
 
 Issues


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
